### PR TITLE
Generate dynamic trees in Strawberry Fields biome

### DIFF
--- a/src/main/resources/trees/dtneapolitan/world_gen/default.json
+++ b/src/main/resources/trees/dtneapolitan/world_gen/default.json
@@ -67,5 +67,16 @@
         }
       }
     }
+  },
+  {
+    "_comment": "Oak generation in Strawberry Fields biome",
+    "select": "neapolitan:strawberry_fields",
+    "apply": {
+      "species": "oak",
+      "density": [
+        2.0
+      ],
+      "chance": 0.1
+    }
   }
 ]

--- a/src/main/resources/trees/dtneapolitan/world_gen/feature_cancellers.json
+++ b/src/main/resources/trees/dtneapolitan/world_gen/feature_cancellers.json
@@ -1,0 +1,18 @@
+[
+  {
+    "__comment": "Cancel standard tree features from Strawberry Fields biome.",
+    "select": "neapolitan:strawberry_fields",
+    "cancellers": {
+      "type": "tree",
+      "namespace": "minecraft"
+    }
+  },
+  {
+    "__comment": "Cancel spruce trees near Mint Sprouts.",
+    "select": { "tag": "neapolitan:has_feature/mint_pond"},
+    "cancellers": {
+      "type": "tree",
+      "namespace": "minecraft"
+    }
+  }
+]


### PR DESCRIPTION
Fix #7
![2025-04-13_20 57 49](https://github.com/user-attachments/assets/a269c21a-468e-46c8-8160-850ddb1dee83)

Also remove vanilla spruce trees near Mint Ponds (but without generation of dynamic trees)